### PR TITLE
[#67] Login뷰 textfield와 컴포넌트 동기화 + 레이아웃 디테일

### DIFF
--- a/Cardna-iOS/Cardna-iOS/Configuration/AppExtensions/UIView+.swift
+++ b/Cardna-iOS/Cardna-iOS/Configuration/AppExtensions/UIView+.swift
@@ -14,4 +14,14 @@ extension UIView {
             self.addSubview(view)
         }
     }
+    
+    func setViewGradient(startColor: UIColor, endColor: UIColor) {
+        let gradient: CAGradientLayer = CAGradientLayer()
+        gradient.colors = [startColor.cgColor, endColor.cgColor]
+        gradient.locations = [0.0, 1.0]
+        gradient.startPoint = CGPoint(x: 0.0, y: 0.5)
+        gradient.endPoint = CGPoint(x: 1.0, y: 0.5)
+        gradient.frame = bounds
+        layer.addSublayer(gradient)
+    }
 }

--- a/Cardna-iOS/Cardna-iOS/Source/Scene/Login/Extension/LoginViewController+Extension.swift
+++ b/Cardna-iOS/Cardna-iOS/Source/Scene/Login/Extension/LoginViewController+Extension.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+import UIKit
+import SwiftUI
 
 extension LoginViewController {
     func requestLogin() {

--- a/Cardna-iOS/Cardna-iOS/Source/Scene/Login/Login.storyboard
+++ b/Cardna-iOS/Cardna-iOS/Source/Scene/Login/Login.storyboard
@@ -53,17 +53,17 @@
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="T0p-en-pzt">
-                                <rect key="frame" x="16" y="174" width="382" height="1.5"/>
+                                <rect key="frame" x="16" y="174" width="382" height="1"/>
                                 <color key="backgroundColor" systemColor="systemBlueColor"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="1.6000000000000001" id="X6G-MD-idF"/>
+                                    <constraint firstAttribute="height" constant="1" id="X6G-MD-idF"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iSe-Ji-Zgg">
-                                <rect key="frame" x="16" y="246" width="382" height="1.5"/>
+                                <rect key="frame" x="16" y="246" width="382" height="1"/>
                                 <color key="backgroundColor" systemColor="systemPurpleColor"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="1.6000000000000001" id="9ea-3g-2DN"/>
+                                    <constraint firstAttribute="height" constant="1" id="9ea-3g-2DN"/>
                                 </constraints>
                             </view>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="비밀번호 (영문+숫자 최소 8자 이상)" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="hQa-ks-XgW">
@@ -74,9 +74,14 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VA6-3q-rsl">
+                                <rect key="frame" x="16" y="280" width="382" height="64"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="64" id="Qko-0S-eVp"/>
+                                </constraints>
+                            </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tlX-hc-YDK">
                                 <rect key="frame" x="16" y="280" width="382" height="64"/>
-                                <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="64" id="kLG-v9-huo"/>
                                 </constraints>
@@ -86,14 +91,8 @@
                                     <action selector="okButtonDidTap:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="n0z-uu-BFd"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="확인" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="V7r-rr-Plv">
-                                <rect key="frame" x="192" y="301.5" width="30" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jX3-sr-2h6">
-                                <rect key="frame" x="160.5" y="368" width="93" height="21"/>
+                                <rect key="frame" x="160.5" y="368.5" width="93" height="21"/>
                                 <attributedString key="attributedText">
                                     <fragment content="비밀번호 찾기">
                                         <attributes>
@@ -111,7 +110,7 @@
                                     <constraint firstAttribute="height" constant="42" id="M2N-TW-jXA"/>
                                 </constraints>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain"/>
+                                <buttonConfiguration key="configuration" style="plain" title=""/>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GCG-Zu-cBS">
                                 <rect key="frame" x="356" y="204" width="42" height="42"/>
@@ -120,39 +119,51 @@
                                     <constraint firstAttribute="width" secondItem="GCG-Zu-cBS" secondAttribute="height" multiplier="1:1" id="W1W-z7-XIF"/>
                                 </constraints>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain"/>
+                                <buttonConfiguration key="configuration" style="plain" image="icbtEye"/>
+                                <connections>
+                                    <action selector="showPasswordButtonDidTap:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="R5H-qe-ccH"/>
+                                </connections>
                             </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="확인" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sPs-tC-q1V">
+                                <rect key="frame" x="192" y="301.5" width="30" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" red="0.070588235289999995" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" red="0.070588235294117646" green="0.070588235294117646" blue="0.070588235294117646" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="iSe-Ji-Zgg" secondAttribute="trailing" constant="16" id="3RK-sO-MQB"/>
-                            <constraint firstItem="tlX-hc-YDK" firstAttribute="top" secondItem="iSe-Ji-Zgg" secondAttribute="bottom" constant="32.399999999999999" id="8C7-yK-Lni"/>
+                            <constraint firstItem="tlX-hc-YDK" firstAttribute="top" secondItem="xy7-GH-ufJ" secondAttribute="bottom" constant="192" id="8C7-yK-Lni"/>
                             <constraint firstItem="T0p-en-pzt" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="9Fn-Zh-Arm"/>
+                            <constraint firstItem="VA6-3q-rsl" firstAttribute="top" secondItem="xy7-GH-ufJ" secondAttribute="bottom" constant="192" id="9zz-IO-rBn"/>
                             <constraint firstItem="3vF-x1-qFz" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="Ebg-zn-chN"/>
                             <constraint firstItem="tlX-hc-YDK" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="KRX-ek-k4Y"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="GCG-Zu-cBS" secondAttribute="trailing" constant="16" id="L4D-TK-R4E"/>
                             <constraint firstItem="wj5-2C-nA9" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="LqV-EP-sGr"/>
                             <constraint firstItem="jX3-sr-2h6" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="Nn9-AD-eDS"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="T0p-en-pzt" secondAttribute="trailing" constant="16" id="RQj-pQ-Jrf"/>
+                            <constraint firstItem="sPs-tC-q1V" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="Rf6-qK-WiR"/>
                             <constraint firstItem="xy7-GH-ufJ" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="S4n-0e-4YT"/>
                             <constraint firstItem="iSe-Ji-Zgg" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="TEd-6f-igm"/>
                             <constraint firstItem="wj5-2C-nA9" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="132" id="VmF-o3-V0T"/>
                             <constraint firstItem="iSe-Ji-Zgg" firstAttribute="top" secondItem="GCG-Zu-cBS" secondAttribute="bottom" id="XFr-a2-bck"/>
-                            <constraint firstItem="V7r-rr-Plv" firstAttribute="centerY" secondItem="tlX-hc-YDK" secondAttribute="centerY" id="ZP8-Yv-uix"/>
+                            <constraint firstItem="sPs-tC-q1V" firstAttribute="centerY" secondItem="tlX-hc-YDK" secondAttribute="centerY" id="Zt1-Zi-Sf7"/>
+                            <constraint firstItem="jX3-sr-2h6" firstAttribute="centerY" secondItem="wj5-2C-nA9" secondAttribute="centerY" id="aWh-G4-QT2"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="xy7-GH-ufJ" secondAttribute="trailing" id="aXE-BC-5CT"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="3vF-x1-qFz" secondAttribute="trailing" constant="16" id="azG-ka-gUf"/>
                             <constraint firstItem="xy7-GH-ufJ" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="eG0-OJ-qfv"/>
                             <constraint firstItem="T0p-en-pzt" firstAttribute="top" secondItem="3vF-x1-qFz" secondAttribute="bottom" id="eWv-5F-bI8"/>
-                            <constraint firstItem="iSe-Ji-Zgg" firstAttribute="top" secondItem="T0p-en-pzt" secondAttribute="bottom" constant="70.400000000000006" id="fIz-oz-k1L"/>
+                            <constraint firstItem="iSe-Ji-Zgg" firstAttribute="top" secondItem="xy7-GH-ufJ" secondAttribute="bottom" constant="158" id="fIz-oz-k1L"/>
                             <constraint firstItem="iSe-Ji-Zgg" firstAttribute="top" secondItem="hQa-ks-XgW" secondAttribute="bottom" id="gvM-V2-qy4"/>
-                            <constraint firstItem="jX3-sr-2h6" firstAttribute="top" secondItem="tlX-hc-YDK" secondAttribute="bottom" constant="24" id="hFj-Lr-4Yg"/>
+                            <constraint firstItem="VA6-3q-rsl" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="lt8-qZ-mLt"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="VA6-3q-rsl" secondAttribute="trailing" constant="16" id="m9g-Ui-Awy"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="tlX-hc-YDK" secondAttribute="trailing" constant="16" id="qCN-Er-Gl9"/>
-                            <constraint firstItem="V7r-rr-Plv" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="reD-YU-Nxr"/>
                             <constraint firstItem="hQa-ks-XgW" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="usd-7q-kuW"/>
                             <constraint firstItem="GCG-Zu-cBS" firstAttribute="leading" secondItem="hQa-ks-XgW" secondAttribute="trailing" id="v45-xd-iah"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="wj5-2C-nA9" secondAttribute="trailing" constant="132" id="vaY-Bx-006"/>
-                            <constraint firstItem="wj5-2C-nA9" firstAttribute="top" secondItem="tlX-hc-YDK" secondAttribute="bottom" constant="14" id="wXc-Mz-cYT"/>
+                            <constraint firstItem="wj5-2C-nA9" firstAttribute="top" secondItem="xy7-GH-ufJ" secondAttribute="bottom" constant="270" id="wXc-Mz-cYT"/>
                             <constraint firstItem="T0p-en-pzt" firstAttribute="top" secondItem="xy7-GH-ufJ" secondAttribute="bottom" constant="86" id="zZz-DP-KaX"/>
                         </constraints>
                     </view>
@@ -160,12 +171,15 @@
                         <outlet property="backButton" destination="dUh-8m-QiW" id="S3H-Wj-1Ov"/>
                         <outlet property="emailTextField" destination="3vF-x1-qFz" id="D87-cy-At8"/>
                         <outlet property="emailUnderView" destination="T0p-en-pzt" id="rwY-Xb-Esg"/>
+                        <outlet property="emailUnderViewHeight" destination="X6G-MD-idF" id="OsA-GY-1dH"/>
                         <outlet property="findPasswordButton" destination="wj5-2C-nA9" id="tVh-KG-gPf"/>
                         <outlet property="findPasswordLabel" destination="jX3-sr-2h6" id="oUa-FA-DyG"/>
                         <outlet property="okButton" destination="tlX-hc-YDK" id="ojf-jl-083"/>
-                        <outlet property="okLabel" destination="V7r-rr-Plv" id="nIN-GI-eF2"/>
+                        <outlet property="okLabel" destination="sPs-tC-q1V" id="6N2-dX-zqg"/>
+                        <outlet property="okView" destination="VA6-3q-rsl" id="pcN-fb-fRH"/>
                         <outlet property="passwordTextField" destination="hQa-ks-XgW" id="mJy-xt-GUA"/>
                         <outlet property="passwordUnderView" destination="iSe-Ji-Zgg" id="8HG-tT-Zut"/>
+                        <outlet property="passwordUnderViewHeight" destination="9ea-3g-2DN" id="2Jf-cy-Wty"/>
                         <outlet property="showPasswordButton" destination="GCG-Zu-cBS" id="yqg-sz-OY4"/>
                         <outlet property="titleLabel" destination="Ksk-Sw-EuT" id="NEm-Zf-jBS"/>
                     </connections>
@@ -177,6 +191,7 @@
     </scenes>
     <resources>
         <image name="icbtBack" width="42" height="42"/>
+        <image name="icbtEye" width="42" height="42"/>
         <systemColor name="systemBlueColor">
             <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/Cardna-iOS/Cardna-iOS/Source/Scene/Login/LoginViewController.swift
+++ b/Cardna-iOS/Cardna-iOS/Source/Scene/Login/LoginViewController.swift
@@ -19,9 +19,12 @@ class LoginViewController: UIViewController {
     @IBOutlet weak var showPasswordButton: UIButton!
     @IBOutlet weak var passwordUnderView: UIView!
     @IBOutlet weak var okButton: UIButton!
+    @IBOutlet weak var okView: UIView!
     @IBOutlet weak var okLabel: UILabel!
     @IBOutlet weak var findPasswordButton: UIButton!
     @IBOutlet weak var findPasswordLabel: UILabel!
+    @IBOutlet weak var emailUnderViewHeight: NSLayoutConstraint!
+    @IBOutlet weak var passwordUnderViewHeight: NSLayoutConstraint!
     
     // MARK: - VC Life Cycle
     
@@ -36,7 +39,10 @@ class LoginViewController: UIViewController {
     private func setInitialState() {
         okButton.isEnabled = false
         passwordTextField.isSecureTextEntry = true
-        showPasswordButton.isEnabled = false
+        showPasswordButton.isHidden = true
+        showPasswordButton.isSelected = false
+        emailTextField.addTarget(self, action: #selector(textFieldDidChange(_:)), for: .editingChanged)
+        passwordTextField.addTarget(self, action: #selector(textFieldDidChange(_:)), for: .editingChanged)
     }
     
     private func setUI() {
@@ -57,22 +63,23 @@ class LoginViewController: UIViewController {
     private func setLabelUI() {
         titleLabel.font = .cardnaSh1Sbd
         titleLabel.textColor = .w1
-        okLabel.font = .cardnaH6Rg
-        okLabel.textColor = .w2
         findPasswordLabel.font = .cardnaB3Rg
         findPasswordLabel.textColor = .w3
+        okLabel.font = .cardnaH6Rg
+        okLabel.textColor = .w2
     }
     
     private func setViewUI() {
+        okView.layer.cornerRadius = 10
+        okView.backgroundColor = .w3
+        okView.clipsToBounds = true
         emailUnderView.backgroundColor = .w4
         passwordUnderView.backgroundColor = .w4
     }
     
     private func setButtonUI() {
-        showPasswordButton.setBackgroundImage(Const.Image.icbtBox, for: .normal)
-        okButton.backgroundColor = .w3
-        okButton.layer.cornerRadius = 10
-        okButton.setBackgroundImage(Const.Image.gradientbg, for: .normal)
+        showPasswordButton.setImage(Const.Image.icbtEye, for: .normal)
+        showPasswordButton.setImage(Const.Image.icbtEyeslash, for: .selected)
     }
     
     func makeAlert(data: GeneralResponse<LoginResponse>) {
@@ -84,9 +91,60 @@ class LoginViewController: UIViewController {
         self.present(alert, animated: true, completion: nil)
     }
     
+    func setButtonEnable() {
+        if emailTextField.hasText && passwordTextField.hasText {
+            okButton.isEnabled = true
+            okView.setViewGradient(startColor: .mainGreen, endColor: .mainPurple)
+            okLabel.font = .cardnaH5Sbd
+            okLabel.textColor = .black
+        }
+        else {
+            okButton.isEnabled = false
+            okView.setViewGradient(startColor: .w3, endColor: .w3)
+            okView.backgroundColor = .w3
+            okLabel.font = .cardnaH6Rg
+            okLabel.textColor = .w2
+        }
+    }
+    
+    // MARK: - objc function
+    
+    @objc
+    func textFieldDidChange(_ textField : UITextField) {
+        setButtonEnable()
+        if textField == emailTextField {
+            if emailTextField.hasText {
+                emailUnderView.backgroundColor = .w1
+                emailUnderViewHeight.constant = 2
+            }
+            else {
+                emailUnderView.backgroundColor = .w4
+                emailUnderViewHeight.constant = 1
+            }
+        }
+        else if textField == passwordTextField {
+            if passwordTextField.hasText {
+                showPasswordButton.isHidden = false
+                passwordUnderView.backgroundColor = .w1
+                passwordUnderViewHeight.constant = 2
+            }
+            else {
+                showPasswordButton.isHidden = true
+                passwordUnderView.backgroundColor = .w4
+                passwordUnderViewHeight.constant = 1
+            }
+        }
+    }
+    
     // MARK: - IBAction
     
     @IBAction func okButtonDidTap(_ sender: Any) {
         self.requestLogin()
     }
+    
+    @IBAction func showPasswordButtonDidTap(_ sender: Any) {
+        passwordTextField.isSecureTextEntry = !passwordTextField.isSecureTextEntry
+        showPasswordButton.isSelected = !showPasswordButton.isSelected
+    }
+    
 }


### PR DESCRIPTION
## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed #Issue_number를 적어주세요 -->
closed #67 

## 변경사항
Login뷰 textfield와 컴포넌트 동기화 + 레이아웃 디테일
버튼 색 변하는거까지 완성했고
UIView extension 파일에 뷰 그라데이션 (시작색, 끝색) 넣으면 해주는 익스텐션 함수까지 추가해뒀습니다
radius 있을 경우에는 cliptobounds true로 하고 써야 잘 나옴!

## 참고사항

## 스크린샷
![Simulator Screen Recording - iPhone 13 - 2022-01-19 at 02 37 37](https://user-images.githubusercontent.com/74659491/149989320-6181b999-aab8-44bf-b350-c3ea8a943a79.gif)

