### PR TITLE
[#129] 서버연결 분기처리로 로그인 실패 시 토스트 창에 메세지 띄우기

### DIFF
--- a/Cardna-iOS/Cardna-iOS/Configuration/AppExtensions/UIViewController+.swift
+++ b/Cardna-iOS/Cardna-iOS/Configuration/AppExtensions/UIViewController+.swift
@@ -19,5 +19,5 @@ extension UIViewController {
             toastLabel.layer.cornerRadius = 15;
             toastLabel.clipsToBounds = true
             self.view.addSubview(toastLabel)
-            UIView.animate(withDuration: 2.0, delay: 0.2, options: .curveEaseOut, animations: { toastLabel.alpha = 0.0 }, completion: {(isCompleted) in toastLabel.removeFromSuperview() }) }
+            UIView.animate(withDuration: 3.0, delay: 0.2, options: .curveEaseOut, animations: { toastLabel.alpha = 0.0 }, completion: {(isCompleted) in toastLabel.removeFromSuperview() }) }
 }

--- a/Cardna-iOS/Cardna-iOS/Network/APIServices/LoginAPI/LoginService.swift
+++ b/Cardna-iOS/Cardna-iOS/Network/APIServices/LoginAPI/LoginService.swift
@@ -36,7 +36,7 @@ public class LoginService {
         case 200:
             return isValidLoginData(data: data)
         case 400..<500:
-            return .pathErr
+            return isValidLoginData(data: data)
         case 500:
             return .serverErr
         default:

--- a/Cardna-iOS/Cardna-iOS/Source/Scene/Login/Extension/LoginViewController+Extension.swift
+++ b/Cardna-iOS/Cardna-iOS/Source/Scene/Login/Extension/LoginViewController+Extension.swift
@@ -17,8 +17,12 @@ extension LoginViewController {
         LoginService.shared.postLogin(parameter: LoginRequest.init(email: email, password: password)) { responseData in
             switch responseData {
             case .success(let loginResponse):
+                
                 guard let response = loginResponse as? GeneralResponse<LoginResponse> else { return }
-                self.makeAlert(data: response)
+                if response.status == 404 {
+                    self.showToast(message: response.message ?? "", font: .Pretendard(.regular, size: 12))
+                }
+                else {self.makeAlert(data: response)}
             case .requestErr(let message):
                 print("requestErr \(message)")
             case .pathErr:


### PR DESCRIPTION
## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed #Issue_number를 적어주세요 -->
closed #129 

## 변경사항
서버연결 분기처리로 로그인 실패 시 토스트 창에 메세지 띄우기

## 참고사항
토스트 커스텀에 대해서는 .. 디자인과 함께 얘기를 해봐야 할 것 같기도 합니다..

## 스크린샷
![Simulator Screen Recording - iPhone 12 mini - 2022-01-19 at 08 02 43](https://user-images.githubusercontent.com/74659491/150032903-aa7eabfa-b991-426c-8a20-74a2456f340c.gif)

